### PR TITLE
Rename int/uint to isize/usize or i32/u32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/*
 stage/*
 node_modules/*
 !node_modules/gitbook-plugin-rust-playpen
+target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "foo"
+name = "update"
 version = "0.0.1"
 dependencies = [
  "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,27 @@
+[root]
+name = "foo"
+version = "0.0.1"
+dependencies = [
+ "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex_macros 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex_macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-serialize"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "foo"
+name = "update"
 version = "0.0.1"
 authors = ["Jorge Aparicio <japaricious@gmail.com>",
            "Steve Klabnik <steve@steveklabnik.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+
+name = "foo"
+version = "0.0.1"
+authors = ["Jorge Aparicio <japaricious@gmail.com>",
+           "Steve Klabnik <steve@steveklabnik.com>"]
+
+[dependencies]
+
+rustc-serialize = "*"
+regex = "*"
+regex_macros = "*"

--- a/src/example.rs
+++ b/src/example.rs
@@ -1,10 +1,11 @@
 use file;
 use markdown::Markdown;
-use serialize::{Decodable,json};
+use rustc_serialize::{Decodable,json};
 use std::iter::AdditiveIterator;
 use std::iter::repeat;
+use std::sync::mpsc;
 
-#[deriving(Decodable)]
+#[derive(RustcDecodable)]
 pub struct Example {
     children: Option<Vec<Example>>,
     id: String,
@@ -15,7 +16,7 @@ impl Example {
     pub fn get_list() -> Vec<Example> {
         match file::read(&Path::new("examples/structure.json")) {
             Err(why) => panic!("{}", why),
-            Ok(string) => match json::from_str(string.as_slice()) {
+            Ok(string) => match json::Json::from_str(string.as_slice()) {
                 Err(_) => panic!("structure.json is not valid json"),
                 Ok(json) => {
                     match Decodable::decode(&mut json::Decoder::new(json)) {
@@ -36,7 +37,7 @@ impl Example {
 
     pub fn process(&self,
                    number: Vec<uint>,
-                   tx: Sender<(Vec<uint>, String)>,
+                   tx: mpsc::Sender<(Vec<uint>, String)>,
                    indent: uint,
                    prefix: String)
     {
@@ -66,7 +67,7 @@ impl Example {
                 },
             };
 
-        tx.send((number.clone(), entry));
+        let _ = tx.send((number.clone(), entry));
 
         match self.children {
             None => {},

--- a/src/example.rs
+++ b/src/example.rs
@@ -28,7 +28,7 @@ impl Example {
         }
     }
 
-    pub fn count(&self) -> uint {
+    pub fn count(&self) -> u32 {
         match self.children {
             None => 1,
             Some(ref children) => 1 + children.iter().map(|c| c.count()).sum(),
@@ -36,9 +36,9 @@ impl Example {
     }
 
     pub fn process(&self,
-                   number: Vec<uint>,
-                   tx: mpsc::Sender<(Vec<uint>, String)>,
-                   indent: uint,
+                   number: Vec<usize>,
+                   tx: mpsc::Sender<(Vec<usize>, String)>,
+                   indent: usize,
                    prefix: String)
     {
         let id = self.id.as_slice();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![feature(int_uint)]
 #![feature(plugin)]
 
 #![allow(unstable)]
@@ -38,7 +37,7 @@ fn main() {
 
     let mut entries = range(0, nexamples).map(|_| {
         rx.recv().unwrap()
-    }).collect::<Vec<(Vec<uint>, String)>>();
+    }).collect::<Vec<(Vec<usize>, String)>>();
 
     entries.sort_by(|&(ref i, _), &(ref j, _)| i.cmp(j));
 

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,6 +1,7 @@
 use file;
 use playpen;
 use std::iter::repeat;
+use regex::Regex;
 
 pub struct Markdown<'a, 'b> {
     content: String,
@@ -48,7 +49,7 @@ impl<'a, 'b> Markdown<'a, 'b> {
     fn insert_sources(&mut self) -> Result<(), String> {
         let id = self.id;
         let prefix = self.prefix;
-        let re = regex!(r"\{(.*\.rs)\}");
+        let re = Regex::new(r"\{(.*\.rs)\}").unwrap();
 
         let mut table = Vec::new();
         for line in self.content.as_slice().lines() {
@@ -84,7 +85,7 @@ impl<'a, 'b> Markdown<'a, 'b> {
     fn insert_outputs(&mut self) -> Result<(), String> {
         let id = self.id;
         let prefix = self.prefix;
-        let r = regex!(r"\{(.*)\.out\}");
+        let r = Regex::new(r"\{(.*)\.out\}").unwrap();
 
         let dir = Path::new(format!("bin/{}/{}", prefix, id));
 
@@ -96,9 +97,9 @@ impl<'a, 'b> Markdown<'a, 'b> {
                 None => {},
                 Some(captures) => {
                     let src = captures.at(1);
-                    let input = format!("{{{}.out}}", src);
+                    let input = format!("{{{:?}.out}}", src);
                     let s = try!(file::run(prefix, id, src.unwrap()));
-                    let s = format!("```\n$ rustc {0}.rs && ./{0}\n{1}```",
+                    let s = format!("```\n$ rustc {0:?}.rs && ./{0:?}\n{1:?}```",
                                     src, s);
 
                     table.push((input, s));
@@ -117,7 +118,7 @@ impl<'a, 'b> Markdown<'a, 'b> {
     fn insert_playpen_links(&mut self) -> Result<(), String> {
         let id = self.id;
         let prefix = self.prefix;
-        let re = regex!(r"\{(.*)\.play\}");
+        let re = Regex::new(r"\{(.*)\.play\}").unwrap();
 
         let mut once_ = false;
         let mut table = Vec::new();

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -10,7 +10,7 @@ pub struct Markdown<'a, 'b> {
 }
 
 impl<'a, 'b> Markdown<'a, 'b> {
-    pub fn process(number: &[uint], id: &'a str, title: &str, prefix: &'b str)
+    pub fn process(number: &[usize], id: &'a str, title: &str, prefix: &'b str)
         -> Result<(), String>
     {
         let mut mkd = try!(Markdown::new(number, id, title, prefix));
@@ -23,7 +23,7 @@ impl<'a, 'b> Markdown<'a, 'b> {
         Ok(())
     }
 
-    fn new(number: &[uint], id: &'a str, title: &str, prefix: &'b str)
+    fn new(number: &[usize], id: &'a str, title: &str, prefix: &'b str)
         -> Result<Markdown<'a, 'b>, String>
     {
         let path = Path::new(format!("examples/{}/{}/input.md", prefix, id));


### PR DESCRIPTION
depending upon where they will be used.
Also rename crate name to `update` vs `foo`
